### PR TITLE
ci: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download ÁNYK installer
         run: |
@@ -264,7 +264,7 @@ jobs:
           ls -lh "$DMG_NAME"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ANYK-universal
           path: "*.dmg"
@@ -279,7 +279,7 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ANYK-universal
           path: artifacts

--- a/.github/workflows/update-brainfm-cask.yml
+++ b/.github/workflows/update-brainfm-cask.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Determine version and SHA
         id: info

--- a/.github/workflows/update-casks.yml
+++ b/.github/workflows/update-casks.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -54,7 +54,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Add new NAV form template casks"

--- a/.github/workflows/update-zscaler-split-tunnel-cask.yml
+++ b/.github/workflows/update-zscaler-split-tunnel-cask.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Determine version and SHA
         id: info


### PR DESCRIPTION
Updates actions/checkout v4 to v6, actions/upload-artifact v4 to v7, actions/download-artifact v4 to v8, peter-evans/create-pull-request v6 to v8.