### PR TITLE
feat: add opencode-fork formula + auto-update workflow

### DIFF
--- a/.github/workflows/update-opencode-fork.yml
+++ b/.github/workflows/update-opencode-fork.yml
@@ -35,12 +35,12 @@ jobs:
           SHA256_X64="${PAYLOAD_SHA256_X64:-}"
 
           if [ -z "$VERSION" ]; then
-            VERSION=$(gh api repos/anomalyco/opencode/releases/latest -q '.tag_name' | sed 's/^v//')
+            VERSION=$(gh api repos/balcsida/opencode/releases/latest -q '.tag_name' | sed 's/^v//')
           fi
 
           fetch_sha() {
             local arch="$1"
-            curl -fsSL "https://github.com/anomalyco/opencode/releases/download/v${VERSION}/opencode-darwin-${arch}.zip" \
+            curl -fsSL "https://github.com/balcsida/opencode/releases/download/v${VERSION}/opencode-darwin-${arch}.zip" \
               | shasum -a 256 | awk '{print $1}'
           }
 

--- a/.github/workflows/update-opencode-fork.yml
+++ b/.github/workflows/update-opencode-fork.yml
@@ -1,0 +1,118 @@
+name: Update opencode-fork Formula
+
+on:
+  repository_dispatch:
+    types: [update-opencode-fork]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version without v prefix (e.g. 1.14.29)'
+        required: false
+        type: string
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Determine version and SHAs
+        id: info
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            VERSION="${{ github.event.client_payload.version }}"
+            SHA256_ARM64="${{ github.event.client_payload.sha256_arm64 }}"
+            SHA256_X64="${{ github.event.client_payload.sha256_x64 }}"
+          elif [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          fi
+
+          # If no version provided, fetch latest release from fork
+          if [ -z "${VERSION:-}" ]; then
+            VERSION=$(gh api repos/anomalyco/opencode/releases/latest -q '.tag_name' | sed 's/^v//')
+          fi
+
+          # If no SHAs provided, download and compute them
+          if [ -z "${SHA256_ARM64:-}" ]; then
+            curl -sL "https://github.com/anomalyco/opencode/releases/download/v${VERSION}/opencode-darwin-arm64.zip" \
+              -o opencode-arm64.zip
+            SHA256_ARM64=$(shasum -a 256 opencode-arm64.zip | awk '{print $1}')
+            rm opencode-arm64.zip
+          fi
+
+          if [ -z "${SHA256_X64:-}" ]; then
+            curl -sL "https://github.com/anomalyco/opencode/releases/download/v${VERSION}/opencode-darwin-x64.zip" \
+              -o opencode-x64.zip
+            SHA256_X64=$(shasum -a 256 opencode-x64.zip | awk '{print $1}')
+            rm opencode-x64.zip
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "sha256_arm64=$SHA256_ARM64" >> $GITHUB_OUTPUT
+          echo "sha256_x64=$SHA256_X64" >> $GITHUB_OUTPUT
+
+      - name: Update formula
+        run: |
+          VERSION="${{ steps.info.outputs.version }}"
+          SHA256_ARM64="${{ steps.info.outputs.sha256_arm64 }}"
+          SHA256_X64="${{ steps.info.outputs.sha256_x64 }}"
+          FORMULA="Formula/opencode-fork.rb"
+
+          sed -i "s/version \".*\"/version \"${VERSION}\"/" "$FORMULA"
+
+          # Update arm64 sha256 (first occurrence after on_arm block)
+          python3 - <<'EOF'
+          import re, os, sys
+
+          formula = os.environ.get('FORMULA', 'Formula/opencode-fork.rb')
+          arm64_sha = os.environ.get('SHA256_ARM64', '')
+          x64_sha = os.environ.get('SHA256_X64', '')
+
+          with open(formula) as f:
+              content = f.read()
+
+          # Replace sha256 inside on_arm block
+          content = re.sub(
+              r'(on_arm\s+do.*?sha256 ")([a-f0-9]{64})(")',
+              lambda m: m.group(1) + arm64_sha + m.group(3),
+              content,
+              flags=re.DOTALL,
+          )
+
+          # Replace sha256 inside on_intel block
+          content = re.sub(
+              r'(on_intel\s+do.*?sha256 ")([a-f0-9]{64})(")',
+              lambda m: m.group(1) + x64_sha + m.group(3),
+              content,
+              flags=re.DOTALL,
+          )
+
+          with open(formula, 'w') as f:
+              f.write(content)
+
+          print("Updated formula:")
+          print(content)
+          EOF
+        env:
+          FORMULA: Formula/opencode-fork.rb
+          SHA256_ARM64: ${{ steps.info.outputs.sha256_arm64 }}
+          SHA256_X64: ${{ steps.info.outputs.sha256_x64 }}
+
+      - name: Commit and push
+        run: |
+          VERSION="${{ steps.info.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/opencode-fork.rb
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Update opencode-fork to v${VERSION}"
+            git push
+          fi

--- a/.github/workflows/update-opencode-fork.yml
+++ b/.github/workflows/update-opencode-fork.yml
@@ -24,89 +24,75 @@ jobs:
         id: info
         env:
           GH_TOKEN: ${{ github.token }}
+          PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
+          PAYLOAD_SHA256_ARM64: ${{ github.event.client_payload.sha256_arm64 }}
+          PAYLOAD_SHA256_X64: ${{ github.event.client_payload.sha256_x64 }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            VERSION="${{ github.event.client_payload.version }}"
-            SHA256_ARM64="${{ github.event.client_payload.sha256_arm64 }}"
-            SHA256_X64="${{ github.event.client_payload.sha256_x64 }}"
-          elif [ -n "${{ inputs.version }}" ]; then
-            VERSION="${{ inputs.version }}"
-          fi
+          set -euo pipefail
+          VERSION="${PAYLOAD_VERSION:-$INPUT_VERSION}"
+          SHA256_ARM64="${PAYLOAD_SHA256_ARM64:-}"
+          SHA256_X64="${PAYLOAD_SHA256_X64:-}"
 
-          # If no version provided, fetch latest release from fork
-          if [ -z "${VERSION:-}" ]; then
+          if [ -z "$VERSION" ]; then
             VERSION=$(gh api repos/anomalyco/opencode/releases/latest -q '.tag_name' | sed 's/^v//')
           fi
 
-          # If no SHAs provided, download and compute them
-          if [ -z "${SHA256_ARM64:-}" ]; then
-            curl -sL "https://github.com/anomalyco/opencode/releases/download/v${VERSION}/opencode-darwin-arm64.zip" \
-              -o opencode-arm64.zip
-            SHA256_ARM64=$(shasum -a 256 opencode-arm64.zip | awk '{print $1}')
-            rm opencode-arm64.zip
-          fi
+          fetch_sha() {
+            local arch="$1"
+            curl -fsSL "https://github.com/anomalyco/opencode/releases/download/v${VERSION}/opencode-darwin-${arch}.zip" \
+              | shasum -a 256 | awk '{print $1}'
+          }
 
-          if [ -z "${SHA256_X64:-}" ]; then
-            curl -sL "https://github.com/anomalyco/opencode/releases/download/v${VERSION}/opencode-darwin-x64.zip" \
-              -o opencode-x64.zip
-            SHA256_X64=$(shasum -a 256 opencode-x64.zip | awk '{print $1}')
-            rm opencode-x64.zip
-          fi
+          [ -n "$SHA256_ARM64" ] || SHA256_ARM64=$(fetch_sha arm64)
+          [ -n "$SHA256_X64" ]   || SHA256_X64=$(fetch_sha x64)
 
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "sha256_arm64=$SHA256_ARM64" >> $GITHUB_OUTPUT
-          echo "sha256_x64=$SHA256_X64" >> $GITHUB_OUTPUT
+          {
+            echo "version=$VERSION"
+            echo "sha256_arm64=$SHA256_ARM64"
+            echo "sha256_x64=$SHA256_X64"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Update formula
+        env:
+          FORMULA: Formula/opencode-fork.rb
+          VERSION: ${{ steps.info.outputs.version }}
+          SHA256_ARM64: ${{ steps.info.outputs.sha256_arm64 }}
+          SHA256_X64: ${{ steps.info.outputs.sha256_x64 }}
         run: |
-          VERSION="${{ steps.info.outputs.version }}"
-          SHA256_ARM64="${{ steps.info.outputs.sha256_arm64 }}"
-          SHA256_X64="${{ steps.info.outputs.sha256_x64 }}"
-          FORMULA="Formula/opencode-fork.rb"
+          set -euo pipefail
+          python3 <<'EOF'
+          import os, re
 
-          sed -i "s/version \".*\"/version \"${VERSION}\"/" "$FORMULA"
-
-          # Update arm64 sha256 (first occurrence after on_arm block)
-          python3 - <<'EOF'
-          import re, os, sys
-
-          formula = os.environ.get('FORMULA', 'Formula/opencode-fork.rb')
-          arm64_sha = os.environ.get('SHA256_ARM64', '')
-          x64_sha = os.environ.get('SHA256_X64', '')
+          formula = os.environ['FORMULA']
+          version = os.environ['VERSION']
+          arm64_sha = os.environ['SHA256_ARM64']
+          x64_sha = os.environ['SHA256_X64']
 
           with open(formula) as f:
               content = f.read()
 
-          # Replace sha256 inside on_arm block
+          content = re.sub(r'version "[^"]*"', f'version "{version}"', content, count=1)
           content = re.sub(
-              r'(on_arm\s+do.*?sha256 ")([a-f0-9]{64})(")',
-              lambda m: m.group(1) + arm64_sha + m.group(3),
-              content,
-              flags=re.DOTALL,
+              r'(on_arm\s+do.*?sha256 ")[a-f0-9]{64}(")',
+              lambda m: f'{m.group(1)}{arm64_sha}{m.group(2)}',
+              content, count=1, flags=re.DOTALL,
           )
-
-          # Replace sha256 inside on_intel block
           content = re.sub(
-              r'(on_intel\s+do.*?sha256 ")([a-f0-9]{64})(")',
-              lambda m: m.group(1) + x64_sha + m.group(3),
-              content,
-              flags=re.DOTALL,
+              r'(on_intel\s+do.*?sha256 ")[a-f0-9]{64}(")',
+              lambda m: f'{m.group(1)}{x64_sha}{m.group(2)}',
+              content, count=1, flags=re.DOTALL,
           )
 
           with open(formula, 'w') as f:
               f.write(content)
-
-          print("Updated formula:")
-          print(content)
           EOF
-        env:
-          FORMULA: Formula/opencode-fork.rb
-          SHA256_ARM64: ${{ steps.info.outputs.sha256_arm64 }}
-          SHA256_X64: ${{ steps.info.outputs.sha256_x64 }}
 
       - name: Commit and push
+        env:
+          VERSION: ${{ steps.info.outputs.version }}
         run: |
-          VERSION="${{ steps.info.outputs.version }}"
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/opencode-fork.rb

--- a/Formula/opencode-fork.rb
+++ b/Formula/opencode-fork.rb
@@ -1,18 +1,18 @@
 class OpencodeFork < Formula
   desc "AI-powered development tool (fork with LiteLLM provider support)"
-  homepage "https://github.com/anomalyco/opencode"
-  version "1.14.29"
+  homepage "https://github.com/balcsida/opencode"
+  version "1.14.28-litellm.2"
   license "MIT"
 
   on_macos do
     on_arm do
-      url "https://github.com/anomalyco/opencode/releases/download/v#{version}/opencode-darwin-arm64.zip"
-      sha256 "39c483fe12cffe07bfc050d59df534ca1b5d29d9232da237586f1b6a2ef1c7e1"
+      url "https://github.com/balcsida/opencode/releases/download/v#{version}/opencode-darwin-arm64.zip"
+      sha256 "a71d0976ca863e6dc8b60fb81ccaa09ab5e69a8c4dd40004781d56fe58d043c8"
     end
 
     on_intel do
-      url "https://github.com/anomalyco/opencode/releases/download/v#{version}/opencode-darwin-x64.zip"
-      sha256 "60d1c577998e5171183d55bf91e3bc699d5d91ab9998985d82240c87e2f30fec"
+      url "https://github.com/balcsida/opencode/releases/download/v#{version}/opencode-darwin-x64.zip"
+      sha256 "d2849e9cc34ec422f3ce8ba70d03518a3b18bec759aaab2292c753fbddc3f7b0"
     end
   end
 

--- a/Formula/opencode-fork.rb
+++ b/Formula/opencode-fork.rb
@@ -1,0 +1,26 @@
+class OpencodeFork < Formula
+  desc "AI-powered development tool (fork with LiteLLM provider support)"
+  homepage "https://github.com/anomalyco/opencode"
+  version "1.14.29"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/anomalyco/opencode/releases/download/v#{version}/opencode-darwin-arm64.zip"
+      sha256 "39c483fe12cffe07bfc050d59df534ca1b5d29d9232da237586f1b6a2ef1c7e1"
+    end
+
+    on_intel do
+      url "https://github.com/anomalyco/opencode/releases/download/v#{version}/opencode-darwin-x64.zip"
+      sha256 "60d1c577998e5171183d55bf91e3bc699d5d91ab9998985d82240c87e2f30fec"
+    end
+  end
+
+  def install
+    bin.install "opencode"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/opencode --version 2>&1", 0)
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `Formula/opencode-fork.rb` for the LiteLLM-supporting fork (`balcsida/opencode`), pinned to v1.14.28-litellm.2.
- Adds `.github/workflows/update-opencode-fork.yml` — listens for `repository_dispatch` (`update-opencode-fork`) from the fork's `release-cli` workflow, computes SHAs, and commits the updated formula. Also supports manual `workflow_dispatch` with optional version input; falls back to latest release when called without args.

## Test plan
- [ ] Tap PR merges cleanly to `main`.
- [ ] `brew tap balcsida/tap && brew install balcsida/tap/opencode-fork` succeeds and `opencode --version` reports `1.14.28-litellm.2`.
- [ ] Manual `workflow_dispatch` (no input) successfully updates the formula on a follow-up release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)