### PR TITLE
fix(cask): remove NoQCNoLife macOS floor

### DIFF
--- a/Casks/noqcnolife.rb
+++ b/Casks/noqcnolife.rb
@@ -8,8 +8,6 @@ cask "noqcnolife" do
   homepage "https://github.com/balcsida/NoQCNoLife"
 
   auto_updates false
-  depends_on macos: ">= :high_sierra"
-
   app "NoQCNoLife.app"
 
   uninstall quit: "io.github.balcsida.NoQCNoLife"


### PR DESCRIPTION
## Changed
- Removed the `depends_on macos: ">= :high_sierra"` requirement from `Casks/noqcnolife.rb`.

## Why
Homebrew now disables `depends_on macos: :high_sierra` with no replacement, and the existing string comparison form normalizes to that disabled requirement.

## Impact
The NoQCNoLife cask can load again on current Homebrew instead of failing during cask evaluation.

## Checks
- `brew ruby -e 'require "cask/cask_loader"; require "cask/config"; path = Pathname.new("Casks/noqcnolife.rb").expand_path; cask = Cask::CaskLoader::FromPathLoader.new(path).load(config: Cask::Config.new); puts "loaded #{cask.token}"'`
- `ruby -c Casks/noqcnolife.rb`
- `git diff --check`